### PR TITLE
Error "uninitialized constant OpenIdAuthentication::Railtie::ControllerMethods"

### DIFF
--- a/lib/open_id_authentication.rb
+++ b/lib/open_id_authentication.rb
@@ -38,6 +38,7 @@ module OpenIdAuthentication
   self.store = nil
 
   if Rails.version >= '3'
+    module ControllerMethods; end
     class Railtie < ::Rails::Railtie
       config.app_middleware.use OpenIdAuthentication
 


### PR DESCRIPTION
The Railtie tries to access a the ControllerMethods submodule of 
OpenIdAuthentication, but it's not defined yet. No need to move
it all above, just define it and let the Railtie go.

Once the module is included in ActionController::Base, we can add
more methods to it
